### PR TITLE
Fixed typo for email contact link

### DIFF
--- a/ONETUG/Views/Home/Contact.cshtml
+++ b/ONETUG/Views/Home/Contact.cshtml
@@ -25,7 +25,7 @@
             </a>
         </div>
         <div class="float-left" style="padding-right: 20px">
-            <a href="emailto:@Model.EmailAddress">
+            <a href="mailto:@Model.EmailAddress">
                 <img src="@Url.Content("~/images/icon_email_32.png")" />
             </a>
         </div>


### PR DESCRIPTION
Realized the email link at the bottom of the website was broken when I tried to send an e-mail. Looks like it's just a typo.